### PR TITLE
docs: add usage examples and centralize types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
 # Virtual Web Browser
+
+Virtual Web Browser (VWB) is a Node.js/TypeScript service that runs a remote
+Chromium instance and exposes it through HTTP and WebSocket interfaces. It
+streams video frames, accepts input events, and manages clipboard operations so
+that clients can interact with the browser as if it were local.
+
+## Features
+
+* Launch and control a Chromium session with Puppeteer.
+* Static HTTP server for serving the client bundle.
+* WebSocket server that proxies keyboard, mouse, wheel and clipboard events.
+* Automatic switch between single-client and multi-client modes.
+* Helpers for precise coordinate mapping and clipboard management.
+* Centralized type definitions under `src/types.ts` for consistent reuse.
+
+## Module Exports
+
+### `clipboard`
+- `pasteText(rb, text)` – Paste plain text into the remote page using real
+  clipboard operations.
+
+### `http-server`
+- `createHttpServer(opts)` – Serve the `public` directory and expose a health
+  endpoint. Returns an `HttpServerController`.
+
+### `keyboard`
+- `injectKeyPptr(rb, payload)` – Replay key events in the remote page.
+
+### `mouse`
+- `injectMousePptr(rb, payload)` – Inject mouse movement and clicks.
+- `injectWheelPptr(rb, payload)` – Inject wheel scrolling.
+
+### `remote-browser`
+- `RemoteBrowser` – Wrapper around Puppeteer with helpers for streaming frames,
+  input injection and coordinate mapping.
+
+### `ws-single` and `ws-multi`
+- `createSingleFlow(ctx)` – Flow used when a single client is connected.
+- `createMultiFlow(ctx)` – Flow used when multiple clients are connected with a
+  leader.
+
+### `ws-server`
+- `createWsServer(opts)` – WebSocket server that proxies input to the
+  `RemoteBrowser` and broadcasts frames.
+
+### `types`
+- Shared interfaces: `CliArgs`, `RemoteBrowserStartOptions`,
+  `HttpServerController`, `WsServerController`, `CreateWsServerOptions`,
+  `KeyPayload`, `MousePayload`, `MouseInjectPayload`, `WheelPayload`,
+  `FlowContext`, and `Flow`.
+
+### `cli`
+- Command-line entry point for starting the service.
+
+## Usage
+
+```bash
+ts-node src/cli.ts --url https://example.com --port 8080
+```
+
+This command starts the HTTP and WebSocket servers, launches Chromium and begins
+streaming frames from the provided URL.
+

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,23 +5,7 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { createHttpServer } from "./http-server";
 import { createWsServer } from "./ws-server";
-
-/**
- * CLI arguments definition
- */
-interface CliArgs {
-  url: string;
-  port: number;
-  quality: number;
-  fps: number;
-  headful: boolean;
-  width: number;
-  height: number;
-  token: string;
-  env: "PROD" | "DEV" | "DEBUG" | "TESTING";
-  _: (string | number)[];
-  $0: string;
-}
+import type { CliArgs } from "./types";
 
 /**
  * Parse CLI args with yargs.
@@ -79,8 +63,12 @@ const args = yargs(hideBin(process.argv))
   .strict().argv as unknown as CliArgs;
 
 /**
- * main
- * Orchestrates OS-facing concerns only (signals/env/args).
+ * Entry point for the CLI.
+ *
+ * @example
+ * ```bash
+ * ts-node src/cli.ts --url https://example.com
+ * ```
  */
 const main = async (cli: CliArgs) => {
   try {

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -2,15 +2,29 @@
 import { RemoteBrowser } from "./remote-browser";
 
 /**
- * Paste plain text using real clipboard paste:
- * - Grants permissions
- * - Clears clipboard
- * - Writes text
- * - Sends Ctrl/Cmd+V so sites that listen to 'paste' work as expected
- * Falls back to Input.insertText on failure.
- * @param {RemoteBrowser} rb
- * @param {string} text
- * @returns {Promise<true>}
+ * Paste plain text using the remote clipboard and a real paste keystroke.
+ *
+ * The function grants clipboard permissions, clears existing data, writes the
+ * provided text, and finally triggers the platform-specific paste shortcut. If
+ * any of these steps fails, it falls back to `Input.insertText` via the Chrome
+ * DevTools Protocol.
+ *
+ * @example
+ * ```ts
+ * import { pasteText, RemoteBrowser } from "virtual-web-browser";
+ *
+ * const rb = new RemoteBrowser();
+ * await rb.start({
+ *   url: "https://example.com",
+ *   width: 800,
+ *   height: 600,
+ *   headful: false,
+ *   quality: 60,
+ *   fps: 30,
+ *   onFrame: () => {}
+ * });
+ * await pasteText(rb, "Hello world");
+ * ```
  */
 export async function pasteText(
   rb: RemoteBrowser,

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -3,20 +3,19 @@ import path from "node:path";
 import fs from "node:fs";
 import http from "http";
 import express, { Application } from "express";
+import type { HttpServerController } from "./types";
 
 /**
- * Controller returned by createHttpServer
- */
-export interface HttpServerController {
-  app: Application;
-  server: http.Server;
-  ready: Promise<true>;
-  stop: (code?: number) => Promise<void>;
-}
-
-/**
- * Create and start a static HTTP server for /public.
- * No globals, no external resolve/reject.
+ * Create and start a static HTTP server that serves files from the `public`
+ * directory and exposes a simple health endpoint.
+ *
+ * @example
+ * ```ts
+ * const ctrl = createHttpServer({ port: 8080 });
+ * await ctrl.ready; // server is listening
+ * // ... later
+ * await ctrl.stop();
+ * ```
  */
 export function createHttpServer(opts: { port: number }): HttpServerController {
   // Validate public dir

--- a/src/keyboard.ts
+++ b/src/keyboard.ts
@@ -1,20 +1,7 @@
 /* eslint-disable no-console */
 import { KeyInput } from "puppeteer";
 import { RemoteBrowser } from "./remote-browser";
-
-/**
- * Wire payload from frontend (pure keydown/keyup).
- */
-export interface KeyPayload {
-  type: "down" | "up";
-  key: string; // e.key (e.g. 'ñ', 'Dead', 'Enter', 'Backspace', etc.)
-  code?: string; // e.code (KeyA, ArrowLeft, NumpadEnter, …)
-  repeat?: boolean;
-  ctrl?: boolean;
-  alt?: boolean;
-  shift?: boolean;
-  meta?: boolean;
-}
+import type { KeyPayload } from "./types";
 
 /** Normalize some browser variants to what Puppeteer expects */
 const KEY_NORMALIZE: Record<string, string> = {
@@ -90,6 +77,14 @@ const idFor = (p: KeyPayload) => p.code || p.key || "";
  * - "Dead" → ignore (no down/up).
  * - Control/function or with modifiers → page.keyboard.down/up(key).
  * - Printable w/o modifiers → sendCharacter() (or CDP Input.insertText) on keydown, suppress keyup.
+ */
+/**
+ * Inject a keyboard event into the remote page via Puppeteer.
+ *
+ * @example
+ * ```ts
+ * await injectKeyPptr(rb, { type: "down", key: "Enter" });
+ * ```
  */
 export async function injectKeyPptr(
   rb: RemoteBrowser,

--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -1,47 +1,34 @@
 /* eslint-disable no-console */
 import type { RemoteBrowser } from "./remote-browser";
-
-export interface MousePayload {
-  x: number;
-  y: number;
-  type: "down" | "up" | "move";
-  button?: "left" | "right" | "middle";
-  clickCount?: number;
-  canvasWidth: number;
-  canvasHeight: number;
-}
-export interface WheelPayload {
-  deltaX: number;
-  deltaY: number;
-  x: number;
-  y: number;
-  canvasWidth: number;
-  canvasHeight: number;
-}
+import type {
+  MousePayload,
+  MouseInjectPayload,
+  WheelPayload,
+} from "./types";
 
 /**
- * Inject mouse events using DevTools coordinates computed
- * from either full canvas (1:1) or the drawn image rect (letterboxed).
- * @param rb
- * @param payload
+ * Inject mouse events using DevTools coordinates computed from either the full
+ * canvas (1:1) or a displayed image rectangle.
+ *
+ * @example
+ * ```ts
+ * await injectMousePptr(rb, {
+ *   type: "click",
+ *   x: 10,
+ *   y: 10,
+ *   canvasWidth: 800,
+ *   canvasHeight: 600
+ * });
+ * ```
  */
 export async function injectMousePptr(
   rb: RemoteBrowser,
-  payload: {
-    type: "move" | "down" | "up" | "click" | "dblclick";
-    x: number;
-    y: number;
-    button?: "left" | "right" | "middle";
-    buttonsBits?: number;
-    canvasWidth: number;
-    canvasHeight: number;
-    displayRect?: { x: number; y: number; width: number; height: number };
-  }
+  payload: MouseInjectPayload
 ): Promise<true> {
   try {
     const cdp = rb.getCDP();
 
-    // Optional: ignore clicks that land in letterbox (fuera del draw rect)
+    // Optional: ignore clicks that land in letterbox (outside the draw rect)
     if (
       payload.displayRect &&
       (payload.type === "down" ||
@@ -94,6 +81,21 @@ export async function injectMousePptr(
   }
 }
 
+/**
+ * Inject a mouse wheel event into the remote page.
+ *
+ * @example
+ * ```ts
+ * await injectWheelPptr(rb, {
+ *   deltaX: 0,
+ *   deltaY: -120,
+ *   x: 10,
+ *   y: 10,
+ *   canvasWidth: 800,
+ *   canvasHeight: 600
+ * });
+ * ```
+ */
 export async function injectWheelPptr(
   rb: RemoteBrowser,
   p: WheelPayload

--- a/src/remote-browser.ts
+++ b/src/remote-browser.ts
@@ -1,19 +1,26 @@
 /* eslint-disable no-console */
 import puppeteer, { Browser, Page } from "puppeteer";
-
-export interface RemoteBrowserStartOptions {
-  url: string;
-  width: number;
-  height: number;
-  headful: boolean;
-  quality: number;
-  fps: number;
-  onFrame: (base64: string) => void;
-  onClipboard?: (ev: { action: "copy" | "cut"; text: string }) => void;
-}
+import type { RemoteBrowserStartOptions } from "./types";
 
 /**
- * Minimal RemoteBrowser: starts/stops Chromium, streams frames and exposes CDP + mapper.
+ * Minimal wrapper around Puppeteer that launches Chromium, streams frames and
+ * exposes helper methods for input injection and coordinate mapping.
+ *
+ * @example
+ * ```ts
+ * const rb = new RemoteBrowser();
+ * await rb.start({
+ *   url: "https://example.com",
+ *   width: 1280,
+ *   height: 720,
+ *   headful: false,
+ *   quality: 60,
+ *   fps: 30,
+ *   onFrame: (img) => console.log(img.slice(0, 20)),
+ * });
+ * // ...
+ * await rb.stop();
+ * ```
  */
 export class RemoteBrowser {
   private browser: Browser | null = null;
@@ -324,7 +331,7 @@ export class RemoteBrowser {
         }
         return true;
       } catch (permOrWriteErr) {
-        // Fallback: direct insert (won't fire paste handlers but evita concatenación)
+        // Fallback: direct insert (won't fire paste handlers but avoids concatenation)
         try {
           await this.getCDP().send("Input.insertText", { text });
           return true;
@@ -341,8 +348,6 @@ export class RemoteBrowser {
       throw new Error("RB_PASTE_FAIL");
     }
   }
-
-  // Dentro de class RemoteBrowser
 
   /**
    * Map from client canvas coordinates + drawn image rectangle

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,14 +2,184 @@
 import type { Application } from "express";
 import type { Server } from "http";
 import type { WebSocket } from "ws";
-import { RemoteBrowser } from "./remote-browser";
+import type { RemoteBrowser } from "./remote-browser";
 
-/** Controller to stop WS server */
+/**
+ * CLI arguments definition.
+ *
+ * @example
+ * ```ts
+ * const args: CliArgs = {
+ *   url: "https://example.com",
+ *   port: 8080,
+ *   quality: 60,
+ *   fps: 30,
+ *   headful: false,
+ *   width: 1280,
+ *   height: 720,
+ *   token: "",
+ *   env: "PROD",
+ *   _: [],
+ *   $0: "",
+ * };
+ * ```
+ */
+export interface CliArgs {
+  url: string;
+  port: number;
+  quality: number;
+  fps: number;
+  headful: boolean;
+  width: number;
+  height: number;
+  token: string;
+  env: "PROD" | "DEV" | "DEBUG" | "TESTING";
+  _: (string | number)[];
+  $0: string;
+}
+
+/**
+ * Options for {@link RemoteBrowser.start}.
+ *
+ * @example
+ * ```ts
+ * const opts: RemoteBrowserStartOptions = {
+ *   url: "https://example.com",
+ *   width: 1280,
+ *   height: 720,
+ *   headful: false,
+ *   quality: 60,
+ *   fps: 30,
+ *   onFrame: (img) => console.log(img.slice(0, 20)),
+ * };
+ * ```
+ */
+export interface RemoteBrowserStartOptions {
+  url: string;
+  width: number;
+  height: number;
+  headful: boolean;
+  quality: number;
+  fps: number;
+  onFrame: (base64: string) => void;
+  onClipboard?: (ev: { action: "copy" | "cut"; text: string }) => void;
+}
+
+/** Controller returned by {@link createHttpServer}. */
+export interface HttpServerController {
+  app: Application;
+  server: Server;
+  ready: Promise<true>;
+  stop: (code?: number) => Promise<void>;
+}
+
+/**
+ * Payload representing a keyboard event forwarded from the client.
+ *
+ * @example
+ * ```ts
+ * const payload: KeyPayload = { type: "down", key: "a" };
+ * ```
+ */
+export interface KeyPayload {
+  /** Event type: keydown or keyup */
+  type: "down" | "up";
+  /** Value from `KeyboardEvent.key` (e.g. "a", "Enter") */
+  key: string;
+  /** Optional value from `KeyboardEvent.code` (e.g. "KeyA") */
+  code?: string;
+  /** Whether the key is autorepeat */
+  repeat?: boolean;
+  /** Control modifier pressed */
+  ctrl?: boolean;
+  /** Alt/Option modifier pressed */
+  alt?: boolean;
+  /** Shift modifier pressed */
+  shift?: boolean;
+  /** Meta/Command modifier pressed */
+  meta?: boolean;
+}
+
+/**
+ * Mouse event payload originating from the client canvas.
+ *
+ * @example
+ * ```ts
+ * const p: MousePayload = {
+ *   x: 10,
+ *   y: 20,
+ *   type: "move",
+ *   canvasWidth: 800,
+ *   canvasHeight: 600,
+ * };
+ * ```
+ */
+export interface MousePayload {
+  x: number;
+  y: number;
+  type: "down" | "up" | "move";
+  button?: "left" | "right" | "middle";
+  clickCount?: number;
+  canvasWidth: number;
+  canvasHeight: number;
+}
+
+/**
+ * Payload used by {@link injectMousePptr}.
+ *
+ * @example
+ * ```ts
+ * const p: MouseInjectPayload = {
+ *   type: "click",
+ *   x: 10,
+ *   y: 10,
+ *   canvasWidth: 800,
+ *   canvasHeight: 600,
+ * };
+ * ```
+ */
+export interface MouseInjectPayload {
+  type: "move" | "down" | "up" | "click" | "dblclick";
+  x: number;
+  y: number;
+  button?: "left" | "right" | "middle";
+  buttonsBits?: number;
+  canvasWidth: number;
+  canvasHeight: number;
+  displayRect?: { x: number; y: number; width: number; height: number };
+}
+
+/**
+ * Wheel event payload from the client.
+ *
+ * @example
+ * ```ts
+ * const w: WheelPayload = {
+ *   deltaX: 0,
+ *   deltaY: -100,
+ *   x: 10,
+ *   y: 10,
+ *   canvasWidth: 800,
+ *   canvasHeight: 600,
+ * };
+ * ```
+ */
+export interface WheelPayload {
+  deltaX: number;
+  deltaY: number;
+  x: number;
+  y: number;
+  canvasWidth: number;
+  canvasHeight: number;
+}
+
+/** Controller returned by {@link createWsServer}. */
 export interface WsServerController {
+  /** Gracefully stop the WebSocket server. */
   stop: () => Promise<void>;
 }
 
-/** Factory options */
+/** Options for {@link createWsServer}. */
 export interface CreateWsServerOptions {
   app: Application;
   server: Server;
@@ -23,7 +193,23 @@ export interface CreateWsServerOptions {
   fps: number;
 }
 
-/** Minimal helpers the flows need */
+/**
+ * Helpers provided to flow implementations.
+ *
+ * @example
+ * ```ts
+ * const ctx: FlowContext = {
+ *   opts,
+ *   rb,
+ *   ensureRemoteBrowser,
+ *   clients: new Map(),
+ *   wsSend: () => {},
+ *   broadcast: () => {},
+ *   lastFrameRef: { value: null },
+ *   getMetrics: () => ({ deviceWidth: 0, deviceHeight: 0 })
+ * };
+ * ```
+ */
 export interface FlowContext {
   opts: CreateWsServerOptions;
   rb: RemoteBrowser;
@@ -39,7 +225,21 @@ export interface FlowContext {
   /** Device metrics getter */
   getMetrics: () => { deviceWidth: number; deviceHeight: number };
 }
-/** Flow interface: single/multi */
+
+/**
+ * Flow interface used by the WebSocket server to handle different modes.
+ *
+ * @example
+ * ```ts
+ * const flow: Flow = {
+ *   name: "single",
+ *   onSwitchIn: () => {},
+ *   onConnect: async () => {},
+ *   onDisconnect: async () => {},
+ *   onMessage: async () => {}
+ * };
+ * ```
+ */
 export interface Flow {
   name: "single" | "multi";
   onSwitchIn: () => void | Promise<void>;

--- a/src/ws-multi.ts
+++ b/src/ws-multi.ts
@@ -5,7 +5,7 @@ import { injectMousePptr, injectWheelPptr } from "./mouse";
 import { injectKeyPptr } from "./keyboard";
 import { pasteText } from "./clipboard";
 
-/** Find the WS currently using a CID (if any) */
+/** Find the WebSocket currently using a CID (if any). */
 function findWsByCid(
   clients: Map<WebSocket, { cid: number }>,
   cid: number
@@ -14,6 +14,16 @@ function findWsByCid(
   return null;
 }
 
+/**
+ * Multi-client flow where one client is the leader and controls viewport
+ * resizing. All clients receive frames and cursor broadcasts.
+ *
+ * @example
+ * ```ts
+ * const flow = createMultiFlow(ctx);
+ * flow.onSwitchIn();
+ * ```
+ */
 export function createMultiFlow(ctx: FlowContext): Flow {
   let leaderCid: number | null = null;
 
@@ -81,7 +91,7 @@ export function createMultiFlow(ctx: FlowContext): Flow {
     },
 
     onConnect: async (ws, cid) => {
-      // NO hello proactivo: el cliente enviará hello con su clientId y ahí confirmamos.
+      // No proactive hello: the client will send hello with its clientId and we confirm.
       if (!leaderCid) chooseLeader();
       sendMode();
 
@@ -122,11 +132,11 @@ export function createMultiFlow(ctx: FlowContext): Flow {
             const oldCid = rec.cid;
             const want = Number(msg?.payload?.clientId) | 0;
 
-            // (1) Reasignar CID con "takeover" si está en uso por otro WS
+            // (1) Reassign CID with takeover if it's used by another WS
             if (want > 0 && want !== rec.cid) {
               const other = findWsByCid(ctx.clients, want);
               if (other && other !== ws) {
-                // Cerrar el WS anterior que poseía ese cid; cleanup se hará en el handler base on('close')
+                // Close the previous WS that owned that cid; cleanup happens in the base on('close') handler
                 try {
                   ctx.wsSend(other, {
                     type: "error",
@@ -148,7 +158,7 @@ export function createMultiFlow(ctx: FlowContext): Flow {
                 leaderCid = want;
             }
 
-            // (2) Solo el líder puede resizar
+            // (2) Only the leader may resize
             if (
               msg?.payload &&
               typeof msg.payload.canvasWidth === "number" &&
@@ -166,10 +176,10 @@ export function createMultiFlow(ctx: FlowContext): Flow {
               }
             }
 
-            // (3) Confirmar hello con el CID final (el cliente lo guarda en sessionStorage)
+            // (3) Confirm hello with the final CID (client stores it in sessionStorage)
             sendHello(ws, rec.cid);
 
-            // (4) Enviar modo (métricas/leader)
+            // (4) Send mode (metrics/leader)
             sendMode();
             break;
           }

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -17,6 +17,18 @@ import type {
   WsServerController,
 } from "./types";
 
+/**
+ * Create a WebSocket server that proxies input to a {@link RemoteBrowser} and
+ * broadcasts frames to connected clients. The server automatically switches
+ * between single-client and multi-client flows.
+ *
+ * @example
+ * ```ts
+ * const ctrl = createWsServer({ app, server, url, width, height, headful:false, quality:60, fps:30 });
+ * // later
+ * await ctrl.stop();
+ * ```
+ */
 export function createWsServer(
   opts: CreateWsServerOptions
 ): WsServerController {

--- a/src/ws-single.ts
+++ b/src/ws-single.ts
@@ -5,7 +5,7 @@ import { injectMousePptr, injectWheelPptr } from "./mouse";
 import { injectKeyPptr } from "./keyboard";
 import { pasteText } from "./clipboard";
 
-/** Find the WS currently using a CID (if any) */
+/** Find the WebSocket currently using a CID (if any). */
 function findWsByCid(
   clients: Map<WebSocket, { cid: number }>,
   cid: number
@@ -15,10 +15,14 @@ function findWsByCid(
 }
 
 /**
- * Single-client flow:
- * - The only client can resize viewport freely (1:1).
- * - Sends 'mode' with scaled:false.
- * - No cursor echo (native cursor is visible).
+ * Flow used when only a single client is connected. The client can freely
+ * resize the viewport and receives frames without cursor echo.
+ *
+ * @example
+ * ```ts
+ * const flow = createSingleFlow(ctx);
+ * flow.onSwitchIn();
+ * ```
  */
 export function createSingleFlow(ctx: FlowContext): Flow {
   const sendMode = () => {
@@ -52,8 +56,8 @@ export function createSingleFlow(ctx: FlowContext): Flow {
       sendMode();
     },
 
-    onConnect: async (ws /*, cid provisional (ignorado) */) => {
-      // ⚠️ No proactive hello here; wait for client's "hello" to confirm cid
+    onConnect: async (ws, _cid) => {
+      // No proactive hello here; wait for the client's "hello" to confirm cid
       sendMode();
       try {
         await ctx.ensureRemoteBrowser();


### PR DESCRIPTION
## Summary
- consolidate interface declarations into `src/types.ts`
- update modules to use type-only imports
- note shared types in README

## Testing
- `npm run build:cjs`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a54ca124008326b37e254b3224c788