### PR TITLE
feat: add isolate flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ that clients can interact with the browser as if it were local.
 * Static HTTP server for serving the client bundle.
 * WebSocket server that proxies keyboard, mouse, wheel and clipboard events.
 * Automatic switch between single-client and multi-client modes.
+* Experimental isolated sessions via the `--isolate` flag (currently forces single-client mode and prepares per-session page storage).
 * Helpers for precise coordinate mapping and clipboard management.
 * Centralized type definitions under `src/types.ts` for consistent reuse.
 
@@ -56,9 +57,13 @@ that clients can interact with the browser as if it were local.
 ## Usage
 
 ```bash
-ts-node src/cli.ts --url https://example.com --port 8080
+ts-node src/cli.ts --url https://example.com --port 8080 --isolate
 ```
 
 This command starts the HTTP and WebSocket servers, launches Chromium and begins
 streaming frames from the provided URL.
+
+## TODO
+
+- [ ] Implement isolated session handling when `--isolate` is enabled
 

--- a/src/__tests__/remote-browser.test.ts
+++ b/src/__tests__/remote-browser.test.ts
@@ -1,0 +1,22 @@
+import { RemoteBrowser } from "../remote-browser";
+import type { Page } from "puppeteer";
+
+describe("RemoteBrowser page management", () => {
+  it("stores the page at index 0 when not isolated", () => {
+    const rb = new RemoteBrowser();
+    const pg = {} as Page;
+    rb.page = pg;
+    expect(rb.page).toBe(pg);
+  });
+
+  it("indexes pages by client id when isolated", () => {
+    const rb = new RemoteBrowser();
+    (rb as any).isolate = true;
+    rb.setActiveCid(1);
+    const pg1 = { id: 1 } as unknown as Page;
+    rb.page = pg1;
+    expect(rb.page).toBe(pg1);
+    rb.setActiveCid(2);
+    expect(rb.page).toBeNull();
+  });
+});

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -1,0 +1,22 @@
+import type { CliArgs } from "../types";
+
+describe("CliArgs", () => {
+  it("allows the isolate flag", () => {
+    const args: CliArgs = {
+      url: "https://example.com",
+      port: 8080,
+      quality: 60,
+      fps: 30,
+      headful: false,
+      isolate: true,
+      width: 800,
+      height: 600,
+      token: "",
+      env: "PROD",
+      publicDir: "",
+      _: [],
+      $0: "",
+    };
+    expect(args.isolate).toBe(true);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,17 @@ const args = yargs(hideBin(process.argv))
         : false,
     describe: "Launch Chromium UI (reserved)",
   })
+  .option("isolate", {
+    type: "boolean",
+    default:
+      typeof process.env.ISOLATE === "string"
+        ? ["1", "true", "yes", "on"].includes(
+            process.env.ISOLATE.toLowerCase()
+          )
+        : false,
+    describe:
+      "Give each WebSocket client its own page (no effect yet)",
+  })
   .option("width", {
     type: "number",
     default: Number(process.env.WIDTH) || 1280,
@@ -93,6 +104,7 @@ const main = async (cli: CliArgs) => {
       server: httpCtrl.server,
       token: cli.token,
       url: cli.url,
+      isolate: cli.isolate,
       width: cli.width,
       height: cli.height,
       headful: cli.headful,

--- a/src/remote-browser.ts
+++ b/src/remote-browser.ts
@@ -24,9 +24,47 @@ import type { RemoteBrowserStartOptions } from "./types";
  */
 export class RemoteBrowser {
   private browser: Browser | null = null;
-  private page: Page | null = null;
+  private pages: (Page | null)[] = [];
   private cdp: any | null = null;
   private running = false;
+  private isolate = false;
+  private cid = 0;
+
+  /**
+   * Active Puppeteer page. When `isolate` mode is enabled, the getter and
+   * setter index into {@link pages} using the current client identifier.
+   *
+   * @example
+   * ```ts
+   * const rb = new RemoteBrowser();
+   * rb.page = await browser.newPage(); // stored at index 0
+   * const pg = rb.page; // retrieves from index 0
+   * ```
+   */
+  get page(): Page | null {
+    const idx = this.isolate ? this.cid : 0;
+    return this.pages[idx] || null;
+  }
+
+  set page(p: Page | null) {
+    const idx = this.isolate ? this.cid : 0;
+    this.pages[idx] = p;
+  }
+
+  /**
+   * Set the active client identifier used by the {@link page} accessor when
+   * indexing {@link pages} in isolate mode.
+   *
+   * @example
+   * ```ts
+   * rb.setActiveCid(1);
+   * rb.page = somePage; // stored at index 1
+   * ```
+   * @param cid - Client identifier provided by the WebSocket layer.
+   */
+  setActiveCid(cid: number) {
+    this.cid = cid;
+  }
 
   private deviceWidth = 1280;
   private deviceHeight = 720;
@@ -39,6 +77,8 @@ export class RemoteBrowser {
     try {
       if (this.running) return true;
 
+      this.isolate = opts.isolate;
+      this.cid = 0;
       this.jpegQuality = Math.max(1, Math.min(100, opts.quality));
 
       this.browser = await puppeteer.launch({
@@ -52,11 +92,12 @@ export class RemoteBrowser {
       });
 
       const ctx = await this.browser.createBrowserContext();
-      this.page = await ctx.newPage();
-      await this.page.goto(opts.url, { waitUntil: "domcontentloaded" });
+      const pg = await ctx.newPage();
+      this.page = pg;
+      await pg.goto(opts.url, { waitUntil: "domcontentloaded" });
 
       // CDP session + screencast
-      this.cdp = await this.page.target().createCDPSession();
+      this.cdp = await pg.target().createCDPSession();
       await this.cdp.send("Page.enable");
 
       const everyNthFrame = Math.max(1, Math.round(60 / Math.max(1, opts.fps)));
@@ -84,7 +125,7 @@ export class RemoteBrowser {
       });
 
       // Expose a bridge to send clipboard out to Node
-      await this.page!.exposeFunction(
+      await pg.exposeFunction(
         "__vwbClipboardOut",
         (payload: { action: "copy" | "cut"; text: string }) => {
           try {
@@ -121,15 +162,15 @@ export class RemoteBrowser {
         })();
       `;
 
-      await this.page!.evaluateOnNewDocument(injectClipboardHooks());
+      await pg.evaluateOnNewDocument(injectClipboardHooks());
       try {
-        await this.page!.evaluate(injectClipboardHooks());
+        await pg.evaluate(injectClipboardHooks());
       } catch {}
 
       // Optionally, hook frames as they navigate (best-effort same-origin)
-      this.page!.on("framenavigated", async (frame) => {
+      pg.on("framenavigated", async (frame) => {
         try {
-          if (frame === this.page!.mainFrame()) return; // subframes only
+          if (frame === pg.mainFrame()) return; // subframes only
           await frame.evaluate(injectClipboardHooks());
         } catch {}
       });
@@ -159,6 +200,7 @@ export class RemoteBrowser {
       } catch {}
       this.browser = null;
       this.page = null;
+      this.pages = [];
       return true;
     } catch (e) {
       if (process.env.ENV !== "PROD" || !(e instanceof Error)) console.error(e);
@@ -179,10 +221,20 @@ export class RemoteBrowser {
     }
   }
 
-  /** Expose Puppeteer Page (throws if not ready). */
+  /**
+   * Expose the active Puppeteer {@link Page}. Throws if the page is not
+   * initialized.
+   *
+   * @example
+   * ```ts
+   * const pg = rb.getPage();
+   * pg.goto("https://example.com");
+   * ```
+   */
   getPage() {
-    if (!this.page) throw new Error("NO_PAGE");
-    return this.page;
+    const pg = this.page;
+    if (!pg) throw new Error("NO_PAGE");
+    return pg;
   }
 
   /** Expose current CDP session (throws if not ready). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ import type { RemoteBrowser } from "./remote-browser";
  *   quality: 60,
  *   fps: 30,
  *   headful: false,
+ *   isolate: false,
  *   width: 1280,
  *   height: 720,
  *   token: "",
@@ -30,6 +31,8 @@ export interface CliArgs {
   quality: number;
   fps: number;
   headful: boolean;
+  /** Whether each WebSocket client receives an isolated browser page */
+  isolate: boolean;
   width: number;
   height: number;
   token: string;
@@ -49,6 +52,7 @@ export interface CliArgs {
  *   width: 1280,
  *   height: 720,
  *   headful: false,
+ *   isolate: false,
  *   quality: 60,
  *   fps: 30,
  *   onFrame: (img) => console.log(img.slice(0, 20)),
@@ -60,6 +64,8 @@ export interface RemoteBrowserStartOptions {
   width: number;
   height: number;
   headful: boolean;
+  /** Run the browser in isolated mode (no effect yet) */
+  isolate: boolean;
   quality: number;
   fps: number;
   onFrame: (base64: string) => void;
@@ -187,6 +193,8 @@ export interface CreateWsServerOptions {
   token?: string;
 
   url: string;
+  /** When true each WS client uses a dedicated page */
+  isolate: boolean;
   width: number;
   height: number;
   headful: boolean;

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -64,6 +64,7 @@ export function createWsServer(
     rbStartP = rb
       .start({
         url: opts.url,
+        isolate: opts.isolate,
         width: opts.width,
         height: opts.height,
         headful: opts.headful,
@@ -131,7 +132,11 @@ export function createWsServer(
 
   const recomputeFlow = () => {
     try {
-      const want = clients.size > 1 ? "multi" : "single";
+      const want = opts.isolate
+        ? "single"
+        : clients.size > 1
+        ? "multi"
+        : "single";
       if (flow.name === want) return;
       flow =
         want === "multi"


### PR DESCRIPTION
## Summary
- prepare RemoteBrowser for per-session pages via getter/setter and client tracking
- force single-client flow when --isolate is enabled
- document isolate behavior and add unit tests for page indexing

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a67f1c21348326a85c8e37cb4f4761

## Summary by Sourcery

Add an experimental isolate mode that assigns each WebSocket client its own Puppeteer page and update related CLI, server flow, and documentation.

New Features:
- Introduce the --isolate CLI flag and corresponding start option for RemoteBrowser
- Allow each WebSocket client to receive its own Page instance when isolate mode is enabled
- Add setActiveCid method to RemoteBrowser to switch the active client page index

Enhancements:
- Refactor RemoteBrowser to maintain a pages array with page getter/setter based on client ID
- Force single-client streaming flow in ws-server when isolate mode is active

Documentation:
- Update README to document the --isolate flag and its experimental behavior

Tests:
- Add unit tests for per-session page indexing in RemoteBrowser
- Add type tests for the new isolate option in CLI and start options