### PR TITLE
feat: add isolated browser sessions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ that clients can interact with the browser as if it were local.
 * Static HTTP server for serving the client bundle.
 * WebSocket server that proxies keyboard, mouse, wheel and clipboard events.
 * Automatic switch between single-client and multi-client modes.
+* Optional isolation mode that launches a dedicated browser per WebSocket
+  session.
 * Helpers for precise coordinate mapping and clipboard management.
 * Centralized type definitions under `src/types.ts` for consistent reuse.
 
@@ -61,4 +63,10 @@ ts-node src/cli.ts --url https://example.com --port 8080
 
 This command starts the HTTP and WebSocket servers, launches Chromium and begins
 streaming frames from the provided URL.
+
+To give every client its own browser instance:
+
+```bash
+ts-node src/cli.ts --url https://example.com --port 8080 --isolate
+```
 

--- a/src/__tests__/ws-sessions.test.ts
+++ b/src/__tests__/ws-sessions.test.ts
@@ -1,0 +1,57 @@
+import { createSessionController } from "../ws-sessions";
+import type { WebSocket } from "ws";
+
+jest.mock("../remote-browser", () => {
+  return {
+    RemoteBrowser: jest.fn().mockImplementation(() => ({
+      start: jest.fn().mockResolvedValue(true),
+      stop: jest.fn().mockResolvedValue(true),
+      getMetrics: jest
+        .fn()
+        .mockReturnValue({ deviceWidth: 800, deviceHeight: 600 }),
+    })),
+  };
+});
+
+describe("session controller", () => {
+  const baseOpts = {
+    app: {} as any,
+    server: {} as any,
+    token: "",
+    url: "http://example.com",
+    width: 1,
+    height: 1,
+    headful: false,
+    quality: 1,
+    fps: 1,
+    isolate: false,
+  };
+  const wsSend = jest.fn();
+  const broadcast = jest.fn();
+
+  it("shares browser when isolate false", () => {
+    const ctrl = createSessionController({
+      ...baseOpts,
+      wsSend,
+      broadcast,
+    });
+    const a = ctrl.get({} as WebSocket);
+    const b = ctrl.get({} as WebSocket);
+    expect(a.rb).toBe(b.rb);
+  });
+
+  it("isolates browsers when isolate true", () => {
+    const ctrl = createSessionController({
+      ...baseOpts,
+      isolate: true,
+      wsSend,
+      broadcast,
+    });
+    const ws1 = {} as WebSocket;
+    const ws2 = {} as WebSocket;
+    const a = ctrl.get(ws1);
+    const b = ctrl.get(ws2);
+    expect(a.rb).not.toBe(b.rb);
+  });
+});
+

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,16 @@ const args = yargs(hideBin(process.argv))
         : false,
     describe: "Launch Chromium UI (reserved)",
   })
+  .option("isolate", {
+    type: "boolean",
+    default:
+      typeof process.env.ISOLATE === "string"
+        ? ["1", "true", "yes", "on"].includes(
+            process.env.ISOLATE.toLowerCase()
+          )
+        : false,
+    describe: "Run a dedicated browser for each WebSocket session",
+  })
   .option("width", {
     type: "number",
     default: Number(process.env.WIDTH) || 1280,
@@ -96,6 +106,7 @@ const main = async (cli: CliArgs) => {
       width: cli.width,
       height: cli.height,
       headful: cli.headful,
+      isolate: cli.isolate,
       quality: cli.quality,
       fps: cli.fps,
     });

--- a/src/remote-browser.ts
+++ b/src/remote-browser.ts
@@ -53,7 +53,7 @@ export class RemoteBrowser {
 
       this.browser.on("disconnected", () => {
         console.error("[vwb] Browser closed -> shutting down program");
-        throw new Error("BROWSER_IS_GONE");
+        if (!opts.isolate) throw new Error("BROWSER_IS_GONE");
       });
 
       const pages = Array.from(await this.browser.pages());

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ import type { RemoteBrowser } from "./remote-browser";
  *   quality: 60,
  *   fps: 30,
  *   headful: false,
+ *   isolate: false,
  *   width: 1280,
  *   height: 720,
  *   token: "",
@@ -30,6 +31,7 @@ export interface CliArgs {
   quality: number;
   fps: number;
   headful: boolean;
+  isolate: boolean;
   width: number;
   height: number;
   token: string;
@@ -52,6 +54,7 @@ export interface CliArgs {
  *   quality: 60,
  *   fps: 30,
  *   onFrame: (img) => console.log(img.slice(0, 20)),
+ *   isolate: false,
  * };
  * ```
  */
@@ -64,6 +67,11 @@ export interface RemoteBrowserStartOptions {
   fps: number;
   onFrame: (base64: string) => void;
   onClipboard?: (ev: { action: "copy" | "cut"; text: string }) => void;
+  /**
+   * When true the browser is tied to a single session and disconnects
+   * should not propagate an error.
+   */
+  isolate?: boolean;
 }
 
 /** Controller returned by {@link createHttpServer}. */
@@ -192,6 +200,7 @@ export interface CreateWsServerOptions {
   headful: boolean;
   quality: number;
   fps: number;
+  isolate: boolean;
 }
 
 /**

--- a/src/ws-server.ts
+++ b/src/ws-server.ts
@@ -7,15 +7,10 @@ import expressWs, {
 } from "express-ws";
 import type { WebSocket } from "ws";
 
-import { RemoteBrowser } from "./remote-browser";
 import { createSingleFlow } from "./ws-single";
 import { createMultiFlow } from "./ws-multi";
-import type {
-  CreateWsServerOptions,
-  Flow,
-  FlowContext,
-  WsServerController,
-} from "./types";
+import { createSessionController } from "./ws-sessions";
+import type { CreateWsServerOptions, Flow, WsServerController } from "./types";
 
 /**
  * Create a WebSocket server that proxies input to a {@link RemoteBrowser} and
@@ -39,11 +34,6 @@ export function createWsServer(
   const clients = new Map<WebSocket, { cid: number }>();
   let nextCid = 1;
 
-  // --- RB + frame cache ---
-  const rb = new RemoteBrowser();
-  let rbStartP: Promise<true> | null = null;
-  const lastFrameRef = { value: null as string | null };
-
   // --- helpers ---
   const wsSend = (ws: WebSocket, msg: any) => {
     try {
@@ -59,43 +49,13 @@ export function createWsServer(
       } catch {}
     }
   };
-  const ensureRemoteBrowser = (): Promise<true> => {
-    if (rbStartP) return rbStartP;
-    rbStartP = rb
-      .start({
-        url: opts.url,
-        width: opts.width,
-        height: opts.height,
-        headful: opts.headful,
-        quality: opts.quality,
-        fps: opts.fps,
-        onFrame: (base64) => {
-          lastFrameRef.value = base64;
-          broadcast({ type: "frame", payload: base64 });
-        },
-        onClipboard: (ev) =>
-          broadcast({
-            type: "clipboard",
-            payload: { action: ev.action, text: ev.text || "" },
-          }),
-      })
-      .then((r) => {
-        console.log("[vwb] RemoteBrowser started");
-        return r;
-      })
-      .catch((e) => {
-        rbStartP = null;
-        throw e;
-      });
-    return rbStartP;
-  };
-  const getMetrics = () => {
-    try {
-      const m = (rb as any).getMetrics?.();
-      if (m && m.deviceWidth && m.deviceHeight) return m;
-    } catch {}
-    return { deviceWidth: opts.width, deviceHeight: opts.height };
-  };
+
+  const sessions = createSessionController({ ...opts, wsSend, broadcast });
+  const sharedSession = sessions.get();
+  const rb = sharedSession.rb;
+  const ensureRemoteBrowser = sharedSession.ensureRemoteBrowser;
+  const lastFrameRef = sharedSession.lastFrameRef;
+  const getMetrics = sharedSession.getMetrics;
 
   // --- auth ---
   const isAuthorized = (reqUrl?: string) => {
@@ -118,18 +78,21 @@ export function createWsServer(
   });
 
   // --- Flow switcher ---
-  let flow: Flow = createSingleFlow({
-    opts,
-    rb,
-    ensureRemoteBrowser,
-    clients,
-    wsSend,
-    broadcast,
-    lastFrameRef,
-    getMetrics,
-  });
+  let flow: Flow | null = null;
+  if (!opts.isolate)
+    flow = createSingleFlow({
+      opts,
+      rb,
+      ensureRemoteBrowser,
+      clients,
+      wsSend,
+      broadcast,
+      lastFrameRef,
+      getMetrics,
+    });
 
   const recomputeFlow = () => {
+    if (opts.isolate || !flow) return;
     try {
       const want = clients.size > 1 ? "multi" : "single";
       if (flow.name === want) return;
@@ -178,47 +141,102 @@ export function createWsServer(
 
     const cid = nextCid++;
     clients.set(ws as unknown as WebSocket, { cid });
-    recomputeFlow();
 
-    // delegate
-    try {
-      flow.onConnect(ws as any, cid);
-    } catch {}
+    if (opts.isolate) {
+      const session = sessions.get(ws as any);
+      const localClients = new Map<WebSocket, { cid: number }>([
+        [ws as any, { cid }],
+      ]);
+      const flowLocal = createSingleFlow({
+        opts,
+        rb: session.rb,
+        ensureRemoteBrowser: session.ensureRemoteBrowser,
+        clients: localClients,
+        wsSend,
+        broadcast: (msg: any) => wsSend(ws as any, msg),
+        lastFrameRef: session.lastFrameRef,
+        getMetrics: session.getMetrics,
+      });
+      flowLocal.onSwitchIn();
 
-    // route messages
-    ws.on("message", async (raw) => {
-      try {
-        const s = typeof raw === "string" ? raw : raw.toString();
-        const msg = JSON.parse(s);
-        if (!msg || typeof msg !== "object" || typeof msg.type !== "string")
-          return;
-        await flow.onMessage(ws as any, cid, msg);
-      } catch {
-        wsSend(ws as any, {
-          type: "error",
-          payload: { code: "BAD_MSG", message: "Invalid message" },
-        });
-      }
-    });
+      ws.on("message", async (raw) => {
+        try {
+          const s = typeof raw === "string" ? raw : raw.toString();
+          const msg = JSON.parse(s);
+          if (!msg || typeof msg !== "object" || typeof msg.type !== "string")
+            return;
+          await flowLocal.onMessage(ws as any, cid, msg);
+        } catch {
+          wsSend(ws as any, {
+            type: "error",
+            payload: { code: "BAD_MSG", message: "Invalid message" },
+          });
+        }
+      });
 
-    ws.on("close", () => {
-      clients.delete(ws as unknown as WebSocket);
+      ws.on("close", () => {
+        clients.delete(ws as unknown as WebSocket);
+        sessions.remove(ws as any);
+        try {
+          flowLocal.onDisconnect(ws as any, cid);
+        } catch {}
+      });
+
+      ws.on("error", () => {
+        clients.delete(ws as unknown as WebSocket);
+        try {
+          /* @ts-ignore */ ws.close();
+        } catch {}
+        sessions.remove(ws as any);
+        try {
+          flowLocal.onDisconnect(ws as any, cid);
+        } catch {}
+      });
+    } else {
       recomputeFlow();
-      try {
-        flow.onDisconnect(ws as any, cid);
-      } catch {}
-    });
 
-    ws.on("error", () => {
-      clients.delete(ws as unknown as WebSocket);
+      // delegate
       try {
-        /* @ts-ignore */ ws.close();
+        flow!.onConnect(ws as any, cid);
       } catch {}
-      recomputeFlow();
-      try {
-        flow.onDisconnect(ws as any, cid);
-      } catch {}
-    });
+
+      // route messages
+      ws.on("message", async (raw) => {
+        try {
+          const s = typeof raw === "string" ? raw : raw.toString();
+          const msg = JSON.parse(s);
+          if (!msg || typeof msg !== "object" || typeof msg.type !== "string")
+            return;
+          await flow!.onMessage(ws as any, cid, msg);
+        } catch {
+          wsSend(ws as any, {
+            type: "error",
+            payload: { code: "BAD_MSG", message: "Invalid message" },
+          });
+        }
+      });
+
+      ws.on("close", () => {
+        clients.delete(ws as unknown as WebSocket);
+        sessions.remove(ws as any);
+        recomputeFlow();
+        try {
+          flow!.onDisconnect(ws as any, cid);
+        } catch {}
+      });
+
+      ws.on("error", () => {
+        clients.delete(ws as unknown as WebSocket);
+        try {
+          /* @ts-ignore */ ws.close();
+        } catch {}
+        sessions.remove(ws as any);
+        recomputeFlow();
+        try {
+          flow!.onDisconnect(ws as any, cid);
+        } catch {}
+      });
+    }
   };
 
   (wsApp as unknown as WsApplication).ws("/ws", wsHandler);
@@ -232,10 +250,7 @@ export function createWsServer(
         } catch {}
       }
       clients.clear();
-      try {
-        if (rbStartP) await rb.stop();
-      } catch {}
-      rbStartP = null;
+      await sessions.stopAll();
       console.log("[vwb] WS server stopped");
     } catch (e) {
       if (process.env.ENV !== "PROD" || !(e instanceof Error)) console.error(e);

--- a/src/ws-sessions.ts
+++ b/src/ws-sessions.ts
@@ -1,0 +1,180 @@
+/* eslint-disable no-console */
+import type { WebSocket } from "ws";
+import { RemoteBrowser } from "./remote-browser";
+import type { CreateWsServerOptions } from "./types";
+
+/**
+ * Data associated with a WebSocket session.
+ */
+export interface SessionData {
+  rb: RemoteBrowser;
+  ensureRemoteBrowser: () => Promise<true>;
+  lastFrameRef: { value: string | null };
+  getMetrics: () => { deviceWidth: number; deviceHeight: number };
+}
+
+/** Controller that manages {@link RemoteBrowser} instances per WebSocket. */
+export interface SessionController {
+  /** Obtain session data for a given socket. */
+  get: (ws?: WebSocket) => SessionData;
+  /** Remove and stop the browser for the given socket. */
+  remove: (ws: WebSocket) => Promise<void>;
+  /** Stop all managed browsers. */
+  stopAll: () => Promise<void>;
+}
+
+/**
+ * Create a controller that manages browser instances for WebSocket sessions.
+ * When `isolate` is false a single browser is shared. If true each connection
+ * gets its own browser.
+ *
+ * @example
+ * ```ts
+ * const ctrl = createSessionController({
+ *   ...opts,
+ *   wsSend: (ws, msg) => ws.send(JSON.stringify(msg)),
+ *   broadcast: (msg) => console.log(msg),
+ * });
+ * const session = ctrl.get(socket);
+ * await session.ensureRemoteBrowser();
+ * ```
+ */
+export function createSessionController(
+  opts: CreateWsServerOptions & {
+    wsSend: (ws: WebSocket, msg: any) => void;
+    broadcast: (msg: any) => void;
+  }
+): SessionController {
+  const sessions = new Map<WebSocket, SessionData>();
+
+  const sharedRb = new RemoteBrowser();
+  let sharedStartP: Promise<true> | null = null;
+  const sharedLast = { value: null as string | null };
+
+  const sharedData: SessionData = {
+    rb: sharedRb,
+    ensureRemoteBrowser: () => {
+      if (sharedStartP) return sharedStartP;
+      sharedStartP = sharedRb
+        .start({
+          url: opts.url,
+          width: opts.width,
+          height: opts.height,
+          headful: opts.headful,
+          quality: opts.quality,
+          fps: opts.fps,
+          onFrame: (base64) => {
+            sharedLast.value = base64;
+            opts.broadcast({ type: "frame", payload: base64 });
+          },
+          onClipboard: (ev) =>
+            opts.broadcast({
+              type: "clipboard",
+              payload: { action: ev.action, text: ev.text || "" },
+            }),
+          isolate: opts.isolate,
+        })
+        .then((r) => {
+          console.log("[vwb] RemoteBrowser started");
+          return r;
+        })
+        .catch((e) => {
+          sharedStartP = null;
+          throw e;
+        });
+      return sharedStartP;
+    },
+    lastFrameRef: sharedLast,
+    getMetrics: () => {
+      try {
+        const m = (sharedRb as any).getMetrics?.();
+        if (m && m.deviceWidth && m.deviceHeight) return m;
+      } catch {}
+      return { deviceWidth: opts.width, deviceHeight: opts.height };
+    },
+  };
+
+  const get = (ws?: WebSocket): SessionData => {
+    if (!opts.isolate) return sharedData;
+    let s = ws ? sessions.get(ws) : undefined;
+    if (!s) {
+      const rb = new RemoteBrowser();
+      let startP: Promise<true> | null = null;
+      const last = { value: null as string | null };
+      s = {
+        rb,
+        ensureRemoteBrowser: () => {
+          if (startP) return startP;
+          startP = rb
+            .start({
+              url: opts.url,
+              width: opts.width,
+              height: opts.height,
+              headful: opts.headful,
+              quality: opts.quality,
+              fps: opts.fps,
+              onFrame: (base64) => {
+                last.value = base64;
+                if (ws) opts.wsSend(ws, { type: "frame", payload: base64 });
+              },
+              onClipboard: (ev) =>
+                ws &&
+                opts.wsSend(ws, {
+                  type: "clipboard",
+                  payload: { action: ev.action, text: ev.text || "" },
+                }),
+              isolate: opts.isolate,
+            })
+            .then((r) => {
+              console.log("[vwb] RemoteBrowser started");
+              return r;
+            })
+            .catch((e) => {
+              startP = null;
+              throw e;
+            });
+          return startP;
+        },
+        lastFrameRef: last,
+        getMetrics: () => {
+          try {
+            const m = (rb as any).getMetrics?.();
+            if (m && m.deviceWidth && m.deviceHeight) return m;
+          } catch {}
+          return { deviceWidth: opts.width, deviceHeight: opts.height };
+        },
+      };
+      if (ws) sessions.set(ws, s);
+    }
+    return s;
+  };
+
+  const remove = async (ws: WebSocket): Promise<void> => {
+    if (!opts.isolate) return;
+    const s = sessions.get(ws);
+    if (s) {
+      try {
+        await s.rb.stop();
+      } catch {}
+      sessions.delete(ws);
+    }
+  };
+
+  const stopAll = async (): Promise<void> => {
+    if (opts.isolate) {
+      for (const s of sessions.values()) {
+        try {
+          await s.rb.stop();
+        } catch {}
+      }
+      sessions.clear();
+    } else if (sharedStartP) {
+      try {
+        await sharedRb.stop();
+      } catch {}
+      sharedStartP = null;
+    }
+  };
+
+  return { get, remove, stopAll };
+}


### PR DESCRIPTION
## Summary
- add `--isolate` CLI option and related types
- support per-session RemoteBrowser instances with new session controller
- ensure remote browser disconnects don't crash when isolated
- document isolation mode and add tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6a57994808326aec3ca3fd9d8e55b

## Summary by Sourcery

Add an “isolate” mode that launches a dedicated Chromium instance per WebSocket connection and refactor server logic to route sessions through a new SessionController

New Features:
- Introduce --isolate CLI flag and corresponding type definitions
- Implement SessionController to manage shared or per-connection RemoteBrowser instances based on isolation mode

Bug Fixes:
- Prevent browser disconnects from crashing the process when running in isolate mode

Enhancements:
- Refactor ws-server to delegate RemoteBrowser lifecycle and message routing through SessionController
- Update RemoteBrowser disconnect handler to respect isolation setting

Documentation:
- Document isolation mode and example in README

Tests:
- Add unit tests for ws-sessions behavior